### PR TITLE
Uses stdout to move cursor, Closes #1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "terminal-adventure",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "branchable / chainable terminal forms",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Readline requires that you pass it a stream to move the cursor, and clear the screen, and I was passing stdin instead of stdout. I have no idea why that worked in the first place, which is probably why it stopped working on node v10.